### PR TITLE
Move istanbul into dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.gitignore
-.editorconfig
-.eslintrc
-.jscsrc
-.travis.yml
-tmp/
-*.sublime-*
-*.log
-.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm](http://img.shields.io/npm/v/istanbul-instrumenter-loader.svg?style=flat-square)](https://www.npmjs.org/package/istanbul-instrumenter-loader)
 [![travis](http://img.shields.io/travis/deepsweet/istanbul-instrumenter-loader.svg?style=flat-square)](https://travis-ci.org/deepsweet/istanbul-instrumenter-loader)
 [![climate](http://img.shields.io/codeclimate/github/deepsweet/istanbul-instrumenter-loader.svg?style=flat-square)](https://codeclimate.com/github/deepsweet/istanbul-instrumenter-loader/code)
+[![deps](http://img.shields.io/david/deepsweet/istanbul-instrumenter-loader.svg?style=flat-square)](https://david-dm.org/deepsweet/istanbul-instrumenter-loader#info=dependencies)
 [![peer deps](http://img.shields.io/david/peer/deepsweet/istanbul-instrumenter-loader.svg?style=flat-square)](https://david-dm.org/deepsweet/istanbul-instrumenter-loader#info=peerDependencies)
 [![gratipay](http://img.shields.io/gratipay/deepsweet.svg?style=flat-square)](https://gratipay.com/deepsweet/)
 
@@ -12,7 +13,7 @@ Instrument JS files with [Istanbul](https://github.com/gotwarlost/istanbul) for 
 ### Install
 
 ```sh
-$ npm i -S istanbul-instrumenter-loader
+$ npm i -D istanbul-instrumenter-loader
 ```
 
 ### Usage

--- a/package.json
+++ b/package.json
@@ -20,8 +20,13 @@
     "url": "https://github.com/deepsweet"
   },
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "dependencies": {
+    "istanbul": "^0.3.2"
+  },
   "peerDependencies": {
-    "istanbul": "^0.3.2",
     "webpack": "^1.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
You `require` `istanbul` in this module, therefore it should be in your dependency, not the consumer's.

I also used `files` in package.json, as it's easier to whitelist than blacklist, IMO. The only difference for this package is that no `.npmignore` is included.