### PR TITLE
Add force-sourcemap to embed inline sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var defaultOptions = {
     noAutoWrap: true
 };
 
-module.exports = function(source) {
+module.exports = function(source, sourceMap) {
     var userOptions = loaderUtils.parseQuery(this.query);
     var instrumenter = new istanbul.Instrumenter(
         assign({}, defaultOptions, userOptions)
@@ -19,5 +19,24 @@ module.exports = function(source) {
         this.cacheable();
     }
 
+    // if force sourcemap requested embed inline sources (helps resolve issues with
+    // transpiled languages like typescript
+    if (userOptions['force-sourcemap']) {
+        // if there is no source map, create a dummy one to stop plugins like remap-istanbul complaining
+        if (!sourceMap) {
+            sourceMap = {
+                version: 3,
+                sources: [],
+                sourceRoot: '',
+                names: [],
+                mappings: '',
+                sourcesContent: []
+            };
+        }
+        //encode & append
+        var encoded = new Buffer(JSON.stringify(sourceMap)).toString('base64');
+        source += '\n\n//# sourceMappingURL=data:application/json;base64,' + encoded;
+    }
+    
     return instrumenter.instrumentSync(source, this.resourcePath);
 };


### PR DESCRIPTION
This allows a flag to be added to force the embedding of an inline sourcemap to the file. This resolves issues with webpack not outputting sourcemaps for tools like remap-istanbul to function.

I have published this separately at https://www.npmjs.com/package/sourcemap-istanbul-instrumenter-loader if you want to test
