### PR TITLE
Upgrade to istanbul-lib-instrument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,25 @@
 'use strict';
 
-var istanbul = require('istanbul');
+var istanbulLibInstrument = require('istanbul-lib-instrument');
 var loaderUtils = require('loader-utils');
 var assign = require('object-assign');
 
 var defaultOptions = {
-    embedSource: true,
-    noAutoWrap: true
+    autoWrap: true
 };
 
-module.exports = function(source) {
+module.exports = function(source, sourceMap) {
     var userOptions = loaderUtils.parseQuery(this.query);
-    var instrumenter = new istanbul.Instrumenter(
-        assign({}, defaultOptions, userOptions)
+    var instrumenter = istanbulLibInstrument.createInstrumenter(
+        assign({ produceSourceMap: this.sourceMap }, defaultOptions, userOptions)
     );
 
     if (this.cacheable) {
         this.cacheable();
     }
 
-    return instrumenter.instrumentSync(source, this.resourcePath);
+    var that = this;
+    return instrumenter.instrument(source, this.resourcePath, function (error, source) {
+        that.callback(error, source, instrumenter.lastSourceMap());
+    });
 };

--- a/package.json
+++ b/package.json
@@ -2,14 +2,21 @@
   "name": "istanbul-instrumenter-loader",
   "version": "0.2.0",
   "description": "Istanbul instrumenter loader for webpack",
-  "keywords": [ "webpack", "loader", "istanbul", "coverage" ],
+  "keywords": [
+    "webpack",
+    "loader",
+    "istanbul",
+    "coverage"
+  ],
   "homepage": "https://github.com/deepsweet/istanbul-instrumenter-loader",
   "repository": "deepsweet/istanbul-instrumenter-loader",
   "author": "Kir Belevich <kir@soulshine.in> (https://github.com/deepsweet)",
   "main": "index.js",
-  "files": [ "index.js" ],
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
-    "istanbul": "0.x.x",
+    "istanbul-lib-instrument": "^1.1.1",
     "loader-utils": "0.x.x",
     "object-assign": "4.x.x"
   },


### PR DESCRIPTION
Upgrade loader to use istanbul-lib-instrument to be future prove. 

It also adds support for ES6, so the isparta loader is not needed anymore