### PR TITLE
Support inline source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,15 @@ var istanbulLibInstrument = require('istanbul-lib-instrument');
 var loaderUtils = require('loader-utils');
 var assign = require('object-assign');
 
+var sourceMapRegEx = /(?:\/{2}[#@]{1,2}|\/\*)\s+sourceMappingURL\s*=\s*(data:(?:[^;]+;)+base64,)?(\S+)/;
+
 module.exports = function(source, sourceMap) {
+    // use inline source map, if any    
+    var match = sourceMapRegEx.exec(source);
+    if (!sourceMap && match[1] && match[2]) {
+        sourceMap = JSON.parse(new Buffer(match[2], 'base64').toString('utf8'));
+    }
+
     var userOptions = loaderUtils.parseQuery(this.query);
     var instrumenter = istanbulLibInstrument.createInstrumenter(
         assign({ produceSourceMap: this.sourceMap }, userOptions)


### PR DESCRIPTION
In some build configurations source maps are inlined into code and later used from the coverage object via `embedSource` prop to remap coverage to original code.
However update to version `1.1.0` brings latest version of `istanbul-lib-instrument` which no longer provides `embedSource` ([proof](https://github.com/istanbuljs/istanbul-lib-instrument/blob/master/v0-changes.md)). So source maps get lost and we got "Could not find source map" errors (like here https://github.com/deepsweet/istanbul-instrumenter-loader/issues/35)

This PR handles inline source maps case.