### PR TITLE
update doc to webpack2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ config.set({
     webpack: {
         …
         module: {
-            preLoaders: [
+            rules: [
                 // instrument only testing sources with Istanbul
                 {
                     test: /\.js$/,
                     include: path.resolve('src/components/'),
-                    loader: 'istanbul-instrumenter'
+                    loader: 'istanbul-instrumenter-loader'
                 }
             ]
         }


### PR DESCRIPTION
Should fix [update readme to webpack2 #40](https://github.com/deepsweet/istanbul-instrumenter-loader/issues/40)