### PR TITLE
Add fixWebpackSourcePaths option to coverageIstanbulReporter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ config.set({
     },
     reporters: [ 'progress', 'coverage-istanbul' ],
     coverageIstanbulReporter: {
-        reports: [ 'text-summary' ]
+        reports: [ 'text-summary' ],
+        fixWebpackSourcePaths: true
     },
     …
 });


### PR DESCRIPTION
For anyone using webpack pre-loaders (normally most folks which use linters), webpack changes file paths to `/path/to/pre-loader!src/my/file.ts` which breaks html reports as the source file names are wrong.